### PR TITLE
Refactor calculation of three to the one half to use dynamic calculation

### DIFF
--- a/src/threetotheonehalfpy/calculate.py
+++ b/src/threetotheonehalfpy/calculate.py
@@ -1,2 +1,4 @@
+import math
+
 def calculate_threetotheonehalf():
-    return 1.732050807568877
+    return math.sqrt(3)


### PR DESCRIPTION
This pull request updates the calculate_threetotheonehalf function to use Python's math.sqrt function instead of returning a hardcoded value. This change ensures precision and makes the function more maintainable and clear.